### PR TITLE
Update workshopper to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bin": "./promise.js",
   "preferGlobal": true,
   "dependencies": {
-    "workshopper": "~0.4.1",
+    "workshopper": "~0.5.0",
     "q": "~0.9.7",
     "q-io": "~1.10.6",
     "node-uuid": "~1.4.1",


### PR DESCRIPTION
node.js does not exit after selecting a 'problem' until I click enter.
Version 0.5.0 only has a few bugfixes and updates terminal-menu to
version 0.2.0, which fixes this issue.

Commit f5d141d2108ffa8c7f420700f68afcc7185f17ac in
substack/terminal-menu/index.js seems to have made the difference.