### PR TITLE
Fix removed q-io dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@timothygu/workshopper-wrappedexec": "^0.1.4",
     "es6-promise": "^3.0.2",
     "node-uuid": "~1.4.1",
+    "q-io": "^1.13.2",
     "random-word": "^1.0.2",
     "shasum": "^1.0.2",
     "workshopper-exercise": "^2.3.0",


### PR DESCRIPTION
Final exercises still use q-io (and rightly so), but the dep was gone, killing verifiers (as the package itself needs it to successfully run the solution for comparison).

This will probably need to be tagged and published as 1.0.0-alpha.2 / latest :neutral_face: 