### PR TITLE
Added wording about first and second being global functions

### DIFF
--- a/exercises/promise_after_promise/problem.md
+++ b/exercises/promise_after_promise/problem.md
@@ -85,10 +85,13 @@ That’s quite beautiful, no?
 This task will allow you to demonstrate an understanding how to chain promises
 together using `then`.
 
-Call `first` function in your program. `first()` will return a promise that
+Two functions will be provided as global functions that you can use: `first`
+and `second`.
+
+Call the `first` function in your program. `first()` will return a promise that
 will be fulfilled with a secret value.
 
-Call `second` with the fulfilled value of `first`. Return the promise returned
+Call the `second` with the fulfilled value of `first`. Return the promise returned
 by `second` in your `onFulfilled` callback.
 
 Finally, print the fulfilled value of that new promise with `console.log`.


### PR DESCRIPTION
Simple update to the wording for Exercise 7 to let the user know that `first()` and `second()` are provided globally instead of the user needing to create them.

I'm sure there's an even better way to word this, but I think this will get some users unstuck as they run Exercise 7. I also don't speak French, so I'm afraid I can't update the translation.
