### PR TITLE
Fix to make it possible for errors to match

### DIFF
--- a/exercises/throw_an_error/solution/solution.js
+++ b/exercises/throw_an_error/solution/solution.js
@@ -5,7 +5,7 @@ function parsePromised (json) {
     try {
       fulfill(JSON.parse(json));
     } catch (e) {
-      reject(e);
+      reject(e.message);
     }
   });
 };


### PR DESCRIPTION
The previous version would output the entire error object, making it impossible to match (with the file paths).

Using `e.message` instead makes sure the error matches. I believe it works with the intent of the test (and builds on the use of `error.message` earlier.