### PR TITLE
Some small changes for clarity

### DIFF
--- a/exercises/an_important_rule/problem.fr.md
+++ b/exercises/an_important_rule/problem.fr.md
@@ -54,9 +54,9 @@ De nombreuses bibliothèques de promesses essaient de pallier à ce
 problème en vous fournissant un gestionnaire `done` pour traiter toute
 erreur qui n’aurait pas encore été traitée.  La règle d’or est simple :
 
-> Si vous **ne renvoyez pas** de valeur depuis votre promesse vers
-> le code appelant, ajouter un gestionnaire `done` en fin de chaîne
-> pour vous protéger contre les exceptions non traitées.
+*Si vous **ne renvoyez pas** de valeur depuis votre promesse vers
+le code appelant, ajouter un gestionnaire `done` en fin de chaîne
+pour vous protéger contre les exceptions non traitées.*
 
 Voici un exemple :
 

--- a/exercises/an_important_rule/problem.md
+++ b/exercises/an_important_rule/problem.md
@@ -48,8 +48,8 @@ Many promise libraries try to ameliorate this problem for you
 by providing a `done` handler that simply handles any uncaught
 errors.  The rule of thumb is this:
 
-> If you are **not** returning a value from your promise to a caller,
-> then attach a `done` handler to guard against uncaught exceptions.
+*If you are **not** returning a value from your promise to a caller,
+then attach a `done` handler to guard against uncaught exceptions.*
 
 An example is shown below:
 

--- a/exercises/reject_a_promise/problem.fr.md
+++ b/exercises/reject_a_promise/problem.fr.md
@@ -30,6 +30,8 @@ Pour rappel de la leçon précédente, la méthode `then` d’une promesse prend
 deux fonctions de rappel optionnelles : la première est appelée quand la
 promesse s’accomplit, la seconde quand elle rejette.
 
+Pour plus de détails à propos des objets `Error`, veuillez consulter la [documentation du MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) 
+
 ## Base de travail
 
 ```js

--- a/exercises/reject_a_promise/problem.md
+++ b/exercises/reject_a_promise/problem.md
@@ -28,6 +28,8 @@ As a review from last lesson, a promise's `then` function takes two callbacks:
 the first to be called when the promise is fulfilled and the second when the
 promise is rejected.
 
+For more details on Error objects, you can check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
+
 ## Boilerplate
 
 ```js


### PR DESCRIPTION
This pull request proposes two small changes to the instructions for clarity: 

* For the exercise 'Reject a Promise', I added a line in the Hint section to link to the MDN documentation on `Error` objects, because I (and I suspect others) were confused about the reference to this in the instructions. 
* For 'An Important Rule', I reformatted the 'rule of thumb' slightly because the original version was rendering in hard-to-read dark blue on some black terminal screens. 

Hopefully, these changes will make the instructions a bit easier for new users. I also included both edits in the French version for each exercise. 