### PR TITLE
Fix stack trace check for “multiple promises”

### DIFF
--- a/exercises/multiple_promises/wrap.js
+++ b/exercises/multiple_promises/wrap.js
@@ -5,7 +5,8 @@ function wrap(ctx) {
   var p;
 
   function isInUserCode(stack) {
-    return stack[0].getFileName().substring(0, ctx.mainProgram.length)
+    var filename = stack[0].getFileName();
+    return filename && filename.substring(0, ctx.mainProgram.length)
       === ctx.mainProgram;
   }
 


### PR DESCRIPTION
`getFileName()` returns `null` for calls from internal methods (like the Promise constructor itself).

Fixes: https://github.com/stevekane/promise-it-wont-hurt/issues/122