### PR TITLE
Fix error in excercise 9 "throw an error"

### DIFF
--- a/exercises/throw_an_error/problem.md
+++ b/exercises/throw_an_error/problem.md
@@ -15,7 +15,7 @@ try {
   doSomethingRisky();
   doAnotherRiskyThing();
 } catch (e) {
-  console.log(e);
+  console.log(e.message);
 }
 ```
 

--- a/exercises/throw_an_error/solution/solution.js
+++ b/exercises/throw_an_error/solution/solution.js
@@ -5,7 +5,7 @@ function parsePromised (json) {
     try {
       fulfill(JSON.parse(json));
     } catch (e) {
-      reject(e);
+      reject(e.message);
     }
   });
 };

--- a/exercises/throw_an_error/solution/solution.js
+++ b/exercises/throw_an_error/solution/solution.js
@@ -5,10 +5,14 @@ function parsePromised(json) {
     try {
       fulfill(JSON.parse(json));
     } catch (e) {
-      reject(e.message);
+      reject(e);
     }
   });
 }
 
+function onReject(error) {
+  console.log(error.message);
+}
+
 parsePromised(process.argv[2])
-.then(null, console.log);
+.then(null, onReject);

--- a/exercises/throw_an_error/solution/solution.js
+++ b/exercises/throw_an_error/solution/solution.js
@@ -1,6 +1,6 @@
-'use strict'
+'use strict';
 
-function parsePromised (json) {
+function parsePromised(json) {
   return new Promise(function (fulfill, reject) {
     try {
       fulfill(JSON.parse(json));
@@ -8,7 +8,7 @@ function parsePromised (json) {
       reject(e.message);
     }
   });
-};
+}
 
 parsePromised(process.argv[2])
-.then(null, console.log)
+.then(null, console.log);


### PR DESCRIPTION
### What has been done
A very simple fix for https://github.com/stevekane/promise-it-wont-hurt/issues/126 and https://github.com/stevekane/promise-it-wont-hurt/issues/102

Instead of comparing the console logs of the error objects (which contain different file paths), compare the error _messages_.

Besides fixing the error, this would also make the exercise more consistent with exercise 3 "reject_a_promise" and 6 "shortcuts" which also console.log `error.message` instead of the entire `error` object.

## How to test
- `npm install -g promise-it-wont-hurt@latest`
- Apply this fix
- `promise-it-wont-hurt select throw_an_error`
- create a new file `solution.js` which contains something like this:
```js
function parsePromised (json) {
  return new Promise(function (fulfill, reject) {
    try {
      fulfill(JSON.parse(json));
    } catch (e) {
      reject(e.message);
    }
  });
};

parsePromised(process.argv[2])
.then(null, console.log)
```
- `promise-it-wont-hurt verify solution.js`