### PR TITLE
Fix error in exercise 10 "An important rule"

### DIFF
--- a/exercises/an_important_rule/problem.md
+++ b/exercises/an_important_rule/problem.md
@@ -69,11 +69,11 @@ of functions that **all** print to the console.
    text `"OH NOES"`;
 2. Create a function `iterate` that prints the first argument
    (an integer) to it and then returns that argument + 1;
-3. Create a promise chain that wraps your iterate method using Q's
-   `fcall` then a series of iterations that attempts to perform `iterate`
-   a total of 10 times.
-4. Attach `console.log` as a rejection handler at the bottom of your
-   chain.
+3. Create a promise chain that wraps your iterate method using 
+  `Promise.resolve` then a series of iterations that attempts to perform 
+  `iterate` a total of 10 times.
+4. Attach a rejection handler at the bottom of your chain to print the
+   `error.message` using `console.log`.
 5. Insert a call to `alwaysThrows` after your 5th call of `iterate`
 
 If you have done this correctly, your code should print 1,2,3,4,5,

--- a/exercises/an_important_rule/problem.md
+++ b/exercises/an_important_rule/problem.md
@@ -69,8 +69,9 @@ of functions that **all** print to the console.
    text `"OH NOES"`;
 2. Create a function `iterate` that prints the first argument
    (an integer) to it and then returns that argument + 1;
-3. Create a promise chain that wraps your iterate method, then a series of 
-   iterations that attempts to perform `iterate` a total of 10 times.
+3. Create a promise chain using `Promise.resolve` that wraps your iterate 
+   method, then a series of iterations that attempts to perform `iterate` 
+   a total of 10 times.
 4. Attach a rejection handler at the bottom of your chain to print the
    `error.message` using `console.log`.
 5. Insert a call to `alwaysThrows` after your 5th call of `iterate`

--- a/exercises/an_important_rule/problem.md
+++ b/exercises/an_important_rule/problem.md
@@ -69,9 +69,8 @@ of functions that **all** print to the console.
    text `"OH NOES"`;
 2. Create a function `iterate` that prints the first argument
    (an integer) to it and then returns that argument + 1;
-3. Create a promise chain that wraps your iterate method using 
-  `Promise.resolve` then a series of iterations that attempts to perform 
-  `iterate` a total of 10 times.
+3. Create a promise chain that wraps your iterate method, then a series of 
+   iterations that attempts to perform `iterate` a total of 10 times.
 4. Attach a rejection handler at the bottom of your chain to print the
    `error.message` using `console.log`.
 5. Insert a call to `alwaysThrows` after your 5th call of `iterate`

--- a/exercises/an_important_rule/solution/solution.js
+++ b/exercises/an_important_rule/solution/solution.js
@@ -1,11 +1,13 @@
-function iterate (num) {
-  console.log(num);
-  return ++num;
-};
+'use strict';
 
-function alwaysThrows () {
-  throw new Error("OH NOES");
-};
+function iterate(num) {
+  console.log(num);
+  return num + 1;
+}
+
+function alwaysThrows() {
+  throw new Error('OH NOES');
+}
 
 Promise.resolve(iterate(1))
 .then(iterate)

--- a/exercises/an_important_rule/solution/solution.js
+++ b/exercises/an_important_rule/solution/solution.js
@@ -24,4 +24,4 @@ Promise.resolve(iterate(1))
 .then(iterate)
 .then(iterate)
 .then(iterate)
-.then(null, onReject);
+.catch(onReject);

--- a/exercises/an_important_rule/solution/solution.js
+++ b/exercises/an_important_rule/solution/solution.js
@@ -9,6 +9,10 @@ function alwaysThrows() {
   throw new Error('OH NOES');
 }
 
+function onReject(error) {
+  console.log(error.message);
+}
+
 Promise.resolve(iterate(1))
 .then(iterate)
 .then(iterate)
@@ -20,4 +24,4 @@ Promise.resolve(iterate(1))
 .then(iterate)
 .then(iterate)
 .then(iterate)
-.then(null, console.log);
+.then(null, onReject);


### PR DESCRIPTION
### Context
Fixes https://github.com/stevekane/promise-it-wont-hurt/issues/99 and part of https://github.com/stevekane/promise-it-wont-hurt/issues/83.

### What has been done
- Instead of comparing the console logs of the error objects (which contain different file paths), compare the error _messages_.

Using a rejection handler will also make the exercise more consistent with exercise 3 "reject_a_promise", 6 "shortcuts" and 9 "throw an error" which also console.log `error.message` instead of the entire `error` object.

- Updated the problem to match the solution.
- Fixed some eslint problems.

## How to test
- `npm install -g promise-it-wont-hurt@latest`
- Apply this fix
- `promise-it-wont-hurt select an_important_rule`
- create a new file `solution.js` which contains something like this:
```js
function iterate(num) {
      console.log(num);
      return num + 1;
    }
    
    function alwaysThrows() {
      throw new Error('OH NOES');
    }
    
    function onReject(error) {
      console.log(error.message);
    }
    
    Promise.resolve(iterate(1))
    .then(iterate)
    .then(iterate)
    .then(iterate)
    .then(iterate)
    .then(alwaysThrows)
    .then(iterate)
    .then(iterate)
    .then(iterate)
    .then(iterate)
    .then(iterate)
    .catch(onReject);

```
- `promise-it-wont-hurt verify solution.js`