### PR TITLE
fixed reject_a_promise isInUserCode empty fileName issue in wrapper.js

### DIFF
--- a/exercises/reject_a_promise/wrap.js
+++ b/exercises/reject_a_promise/wrap.js
@@ -6,7 +6,12 @@ function wrap(ctx) {
   var savedPrototype;
 
   function isInUserCode(stack) {
-    return stack[0].getFileName().substring(0, ctx.mainProgram.length)
+    // fileName could be empty while user invoke native function, e.g. Promise
+    var fileName = stack[0].getFileName() 
+    if (!fileName) {
+      return false
+    }
+    return fileName.substring(0, ctx.mainProgram.length)
       === ctx.mainProgram;
   }
 


### PR DESCRIPTION
### Context
Fixes https://github.com/stevekane/promise-it-wont-hurt/issues/125 , also added more details to this issue. 

### What has been done
- Handle empty filename corner case in method `wrapper.js/isInUserCode(stack)`

### How to test
- `npm install -g promise-it-wont-hurt@latest`
- Apply this fix
- Create a file `rejected-promise.js` which contains content below
```
const promise = new Promise(function (resolve, reject) {
  setTimeout(function () {
    reject(new Error('REJECTED!'))
  }, 300)
})

function onReject (error) {
  console.log(error.message)
}

promise.then(null).catch(onReject)
```
- `promise-it-wont-hurt verify rejected-promise.js`

### Expected Behaviour
Output result like `success` or `failed`

