### PR TITLE
Refactor to use Array.push()

### DIFF
--- a/exercises/multiple_promises/solution/solution.js
+++ b/exercises/multiple_promises/solution/solution.js
@@ -8,7 +8,7 @@ function all(a, b) {
     var out = [];
 
     a.then(function (val) {
-      out[0] = val;
+      out.push(val);
       counter++;
 
       if (counter >= 2) {
@@ -17,7 +17,7 @@ function all(a, b) {
     });
 
     b.then(function (val) {
-      out[1] = val;
+      out.push(val);
       counter++;
 
       if (counter >= 2) {


### PR DESCRIPTION
Maybe this is more of a personal choice, but it just seems 'cleaner' to avoid manually accessing indexes in `Array`. I'd rather use `push()`. 

That being said, the focus of this is supposed to be _Promises,_ so maybe this is irrelevant.